### PR TITLE
Error message when --format is missing

### DIFF
--- a/src/chowdren_extractor.cpp
+++ b/src/chowdren_extractor.cpp
@@ -121,6 +121,12 @@ int parse_args(po::variables_map& opts, int argc, char** argv) {
         return 1;
     }
 
+    if (opts["format"].empty()) {
+        std::cout << "Specifying --format is required. See versions.md for more details." << std::endl;
+        optdesc_named.print(std::cout);
+        return 1;
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
Improves the UX, compared to:
```
terminate called after throwing an instance of 'boost::wrapexcept<boost::bad_any_cast>'
  what():  boost::bad_any_cast: failed conversion using boost::any_cast
Aborted (core dumped)
```